### PR TITLE
fix git clone args "--branch branchName" -> --branch branchName

### DIFF
--- a/tasks/git.js
+++ b/tasks/git.js
@@ -138,7 +138,8 @@ module.exports = function (grunt) {
         }
 
         if (options.branch && !options.bare) {
-            args.push('--branch ' + options.branch);
+            args.push('--branch');
+            args.push(options.branch);
         }
 
         // repo comes after the options


### PR DESCRIPTION
The git clone command was generated incorrectly with "--branch branchName" instead of --branch branchName
