### PR TITLE
Added logging and force option to gittag

### DIFF
--- a/tasks/git.js
+++ b/tasks/git.js
@@ -70,16 +70,24 @@ module.exports = function (grunt) {
         var done = this.async();
 
         var args = ["tag"];
+
+        if (this.flags.force || options.force) {
+            args.push("-f");
+        }
+
         if (options.message && options.message.trim() !== '') {
             args.push("-m");
             args.push(options.message);
         }
         args.push(options.tag);
 
+        grunt.log.writeln('Tagging ' + options.tag + ' : ' + (options.message || '[blank]'));
+
         grunt.util.spawn({
             cmd: "git",
             args: args
         }, function (err) {
+            if (err) grunt.log.error(err);
             done(!err);
         });
     });

--- a/test/fixtures/tag_failcase.js
+++ b/test/fixtures/tag_failcase.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = function (grunt) {
+    grunt.initConfig({
+        gittag: {
+            task: {
+                options: {
+                    tag: '0.0.1'
+                }
+            },
+            task2: {
+                options: {
+                    tag: '0.0.1'
+                }
+            }
+        },
+    });
+
+    grunt.loadTasks('../../tasks');
+    grunt.registerTask('default', ['gittag']);
+};

--- a/test/fixtures/tag_force.js
+++ b/test/fixtures/tag_force.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = function (grunt) {
+    grunt.initConfig({
+        gittag: {
+            task: {
+                options: {
+                    tag: '0.0.1'
+                }
+            },
+            task2: {
+                options: {
+                    tag: '0.0.1',
+                    force: true
+                }
+            },
+            task3: {
+                options: {
+                    tag: '0.0.1'
+                }
+            }
+        },
+    });
+
+    grunt.loadTasks('../../tasks');
+    grunt.registerTask('default', ['gittag:task', 'gittag:task2', 'gittag:task3:force']);
+};

--- a/test/tag_test.js
+++ b/test/tag_test.js
@@ -6,29 +6,55 @@ var assert = require('assert');
 var common = require('./common');
 
 describe('tag', function () {
-    var repo = null;
-    var tagexists = null;
-    var tagref = null;
 
-    before(function (done) {
-        var fetchtag = function (repo, cb) {
-            fs.exists(repo.path + '/.git/refs/tags/0.0.1', function (e) {
-                tagexists = e;
-                assert.equal(tagexists, false);
-                cb();
+    describe('when tagging a new branch', function () {
+        var repo = null;
+        var tagexists = null;
+        var tagref = null;
+
+        before(function (done) {
+            var fetchtag = function (repo, cb) {
+                fs.exists(repo.path + '/.git/refs/tags/0.0.1', function (e) {
+                    tagexists = e;
+                    assert.equal(tagexists, false);
+                    cb();
+                });
+            };
+
+            common.setupAndRun('tag', fetchtag, function (err, r) {
+                repo = r;
+                done(err);
+
             });
-        };
 
-        common.setupAndRun('tag', fetchtag, function (err, r) {
-            repo = r;
-            done(err);
         });
+
+        it('should create tag', function (done) {
+            fs.exists(repo.path + '/.git/refs/tags/0.0.1', function (e) {
+                assert.equal(e, true);
+                done();
+            });
+        });
+
     });
 
-    it('should create tag', function (done) {
-        fs.exists(repo.path + '/.git/refs/tags/0.0.1', function (e) {
-            assert.equal(e, true);
-            done();
+    describe('when using an existing tag', function () {
+
+        it('should fail by default', function (done) {
+            common.setupAndRun('tag_failcase', function (err, r) {
+                if (err) {
+                    done();
+                } else {
+                    done(new Error('Tag failcase succeeded unexpectedly'));
+                }
+            });
+        });
+
+        it('should succeed when forced', function (done) {
+            common.setupAndRun('tag_force', function (err, r) {
+                assert.ok(!err);
+                done();
+            });
         });
     });
 });


### PR DESCRIPTION
- added logging so you know what tag and message is being applied, useful for dynamic tagging.
- Added logging on error.
- Added force option as grunt option or task flag, eg `grunt gittag:taskname:force`

Added tests and failcases, hope they fit your style well enough.
