### PR TITLE
Add possibility to run the 'reset' command in a different (user-defined)...

### DIFF
--- a/lib/command_reset.js
+++ b/lib/command_reset.js
@@ -5,9 +5,10 @@ var grunt = require('grunt');
 
 module.exports = function (task, exec, done) {
     var options = task.options({
-        commit: 'HEAD'
+        commit: 'HEAD',
+        directory: process.cwd()
     });
-    
+
     var args = ['reset'];
 
     if (options.mode) {
@@ -26,6 +27,9 @@ module.exports = function (task, exec, done) {
 
     // Add callback
     args.push(done);
+
+    // Run the command in the specified directory
+    grunt.file.setBase(options.directory);
 
     exec.apply(this, args);
 };


### PR DESCRIPTION
Added the option to define a different directory where the `reset` command can run. I had the issue that neither using `grunt.file.setBase` nor `process.chdir` worked for me. Hope you like this little addition.
