### PR TITLE
renamed code example of gitcheckout task

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Whether the branch should be created (optional).
 
 ```js
 grunt.initConfig({
-    gittag: {
+    gitcheckout: {
         task: {
             options: {
                 branch: 'testing',


### PR DESCRIPTION
Instead of naming example of task 'gitcheckout' with name 'gittag'
