### PR TITLE
Support the add "--all" option

### DIFF
--- a/lib/command_commit.js
+++ b/lib/command_commit.js
@@ -3,9 +3,12 @@
 var async = require('grunt').util.async;
 
 module.exports = function (task, exec, done) {
+    var self = this;
+
     var options = task.options({
         message: 'Commit',
-        ignoreEmpty: false
+        ignoreEmpty: false,
+        all: false
     });
 
     function addFiles(files, cb) {
@@ -13,7 +16,16 @@ module.exports = function (task, exec, done) {
     }
 
     function addFile(file, cb) {
-        exec("add", file, cb);
+        var args = ['add', ];
+
+        if (options.all) {
+            args.push('--all');
+        }
+
+        args.push(file);
+        args.push(cb);
+
+        exec.apply(self, args);
     }
 
     function checkStaged(cb) {


### PR DESCRIPTION
This adds support for git add's --all option... Therefore automatically tracking file removals,

I got a lost on how to write a test for this. Any help would be greatly appreciated! ... For now, I just tested it by npm link'ing it to my project and running it with { options: { all: true } }.
