### PR TITLE
Make it possible to specify more that one file for the option path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,7 +599,8 @@ grunt.initConfig({
         format: 'tar.gz',
         prefix: 'your-project-name/',
         treeIsh: 'master',
-        output: '/tmp/your-project-name.tar.gz'
+        output: '/tmp/your-project-name.tar.gz',
+        path: ['README', 'LICENSE']
       }
     }
   }
@@ -639,7 +640,7 @@ Default value: none.
 Adds the `--remote` flag. Instead of making a tar archive from the local repository, retrieve a tar archive from a remote repository.
 
 #### options.path
-Type: `String`
+Type: `Array`
 Default value: none.
 
 Without an optional `path` parameter, all files and subdirectories of the current working directory are included in the archive. If one or more paths are specified, only these are included.

--- a/lib/command_archive.js
+++ b/lib/command_archive.js
@@ -53,7 +53,12 @@ module.exports = function (task, exec, done) {
     // <path>
     // Without an optional path parameter, all files and subdirectories of the current working directory are included in the archive. If one or more paths are specified, only these are included.
     if (options.path) {
-        args.push(options.path);
+        if (grunt.util.kindOf(options.path) === 'string') {
+            // Backwards compatible to <= 0.2.8.
+            options.path = [options.path];
+        }
+
+        args = args.concat(options.path);
     }
 
     // Add callback

--- a/test/archive_test.js
+++ b/test/archive_test.js
@@ -66,4 +66,15 @@ describe('archive', function () {
             .run(done);
     });
 
+    it('should only archive defined files', function (done) {
+        var options = {
+            treeIsh: 'master',
+            path: ['README', 'LICENSE']
+        };
+
+        new Test(command, options)
+            .expect(['archive', 'master', 'README', 'LICENSE'])
+            .run(done);
+    });
+
 });


### PR DESCRIPTION
Make it possible to specify more that one file for the option path.
Add test for the option path and update README.
