### PR TITLE
Fixed brackets in examples for gitpush gitpull and gitmerge

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ grunt.initConfig({
       options: {
         // Target-specific options go here.
       }
+    }
   },
 })
 ```
@@ -534,6 +535,7 @@ grunt.initConfig({
       options: {
 
       }
+    }
   },
 })
 ```
@@ -567,6 +569,7 @@ grunt.initConfig({
       options: {
         // Target-specific options go here.
       }
+    }
   },
 })
 ```


### PR DESCRIPTION
Some brackets where missing in the examples for gitpush, gitpull and gitmerge.
