### PR TITLE
Add noVerify and noStatus options to gitcommit task

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,19 +59,35 @@ Default value: `false`
 
 When `true`, the task will not fail when there are no staged changes (optional).
 
+#### options.noVerify
+Type: `Boolean`
+Default value: `false`
+
+When `true`, the task will commit the changes with the `--no-verify` flag.
+
+#### options.noStatus
+Type: `Boolean`
+Default value: `false`
+
+When `true`, the task will commit the changes with the `--no-status` flag.
+
 ### Usage Examples
 
 Commit options:
 
 * `message`: Commit message
 * `files`: Files to commit
+* `noVerify`: Bypass the pre-commit and commit-msg hooks when committing changes
+* `noStatus`: Do not include the output of `git-status` in the commit message
 
 ```js
 grunt.initConfig({
     gitcommit: {
         task: {
             options: {
-                message: 'Testing'
+                message: 'Testing',
+                noVerify: true,
+                noStatus: false
             },
             files: {
                 src: ['test.txt']
@@ -80,6 +96,7 @@ grunt.initConfig({
     },
 });
 ```
+
 
 ## The "gitrebase" task
 

--- a/lib/command_commit.js
+++ b/lib/command_commit.js
@@ -5,8 +5,21 @@ var async = require('grunt').util.async;
 module.exports = function (task, exec, done) {
     var options = task.options({
         message: 'Commit',
-        ignoreEmpty: false
+        ignoreEmpty: false,
+        noVerify: false,
+        noStatus: false
     });
+    var args = ['commit', '-m', options.message];
+
+    if (options.noVerify) {
+        args.push('--no-verify');
+    }
+
+    if (options.noStatus) {
+        args.push('--no-status');
+    }
+
+    args.push(done);
 
     function addFiles(files, cb) {
         async.forEachSeries(files.src, addFile, cb);
@@ -33,7 +46,7 @@ module.exports = function (task, exec, done) {
             }
 
             if (!options.ignoreEmpty || staged) {
-                exec('commit', '-m', options.message, done);
+                exec.apply(null, args);
             } else {
                 done();
             }

--- a/test/commit_test.js
+++ b/test/commit_test.js
@@ -59,4 +59,36 @@ describe('commit', function () {
             .expect(['diff', '--cached', '--exit-code'], [null, '', 0])
             .run(done);
     });
+
+    it('should add --no-verify arg when noVerify is true', function (done) {
+        var options = {
+            noVerify: true
+        };
+
+        var files = [
+            'test.txt'
+        ];
+
+        new Test(command, options, files)
+            .expect(['add', 'test.txt'])
+            .expect(['diff', '--cached', '--exit-code'], [null, 'diff', 1])
+            .expect(['commit', '-m', 'Commit', '--no-verify'])
+            .run(done);
+    });
+
+    it('should add --no-status arg when noStatus is true', function (done) {
+        var options = {
+            noStatus: true
+        };
+
+        var files = [
+            'test.txt'
+        ];
+
+        new Test(command, options, files)
+            .expect(['add', 'test.txt'])
+            .expect(['diff', '--cached', '--exit-code'], [null, 'diff', 1])
+            .expect(['commit', '-m', 'Commit', '--no-status'])
+            .run(done);
+    });
 });


### PR DESCRIPTION
Add the ability to disable pre-commit hooks and status template...

Example usage:

``` js
grunt.initConfig({
    gitcommit: {
        task: {
            options: {
                message: 'Testing',
                noVerify: true,
                noStatus: true
            },
            files: {
                src: ['test.txt']
            }
        }
    },
});
```

Result:

```
git commit -m 'testing' --no-verify --no-status
```
