### PR TITLE
added recursive flag to clone task, tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,12 @@ Default value: none
 
 Clone the repo into a specific directory instead of the one git decides.
 
+#### options.recursive
+Type: `boolean`
+Default value: none
+
+Pass the --recursive flag to the git clone command. This is equivalent to running git submodule update --init --recursive immediately after the clone is finished.
+
 ### Usage Examples
 
 ```js

--- a/lib/command_clone.js
+++ b/lib/command_clone.js
@@ -6,6 +6,7 @@ var grunt = require('grunt');
 module.exports = function (task, exec, done) {
     var options = task.options({
         bare: false,
+        recursive: false,
         branch: false,
         repository: false,
         directory: false
@@ -21,6 +22,10 @@ module.exports = function (task, exec, done) {
 
     if (options.bare) {
         args.push('--bare');
+    }
+
+    if (options.recursive) {
+        args.push('--recursive');
     }
 
     if (options.branch && !options.bare) {

--- a/test/clone_test.js
+++ b/test/clone_test.js
@@ -68,4 +68,14 @@ describe('clone', function () {
             .expect(['clone', '--bare', 'https://github.com/rubenv/gitclone-test.git'])
             .run(done);
     });
+    it('should recursively clone repo and all submodules', function (done) {
+        var options = {
+            repository: 'https://github.com/rubenv/gitclone-test.git',
+            recursive: true
+        };
+
+        new Test(command, options)
+            .expect(['clone', '--recursive', 'https://github.com/rubenv/gitclone-test.git'])
+            .run(done);
+    });
 });


### PR DESCRIPTION
Added an additional option to the gitclone task. The option is called **recursive**, and if set to a truey value, will add a `--recursive` argument to  the call to git clone.

The --recursive flag will instruct git to update and initialize all submodules in the cloned directory:

> > This is equivalent to running git submodule update --init --recursive immediately after the clone is finished 

Also added tests and documentation in README.md. Resolves #55.
