### PR TITLE
add note about using cwd with files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Type: `string`
 Default value: `none`
 
 Change the current working directory before executing the git call. Useful for performing operations on repositories that are located in subdirectories.
-**Note:** When performing commands that provide files (e.g. gitcommit), it is also necessary to specify the cwd for the files explicitly.
+**Note:** When performing commands that provide files (e.g. gitcommit), it is also necessary to specify the ``cwd`` for the files explicitly.
 
 #### Example:
 ```js


### PR DESCRIPTION
As @ZuBB pointed out, the cwd option will not work with grunt-git commands that use the grunt file tools. The reason is that the cwd option is only applied to the spawned child processes that make calls to the git CLI. On the other hand, files are evaluated in the context of the Gruntfile's current working directory by default, so any action performed on files by the main thread will be done in the context of the Gruntfile's cwd. 

It might be possible to re-expand the user-provided file object using the options.cwd by calling `grunt.file.setBase(options.cwd)` if options.cwd is valid, but I think it is important to update the documentation for now. 
