### PR TITLE
allow deletion of tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ grunt.initConfig({
 
 ## The "gittag" task
 
-Creates a git tag.
+Creates (or deletes) a git tag.
 
 ### Overview
 In your project's Gruntfile, add a section named `gittag` to the data object passed into `grunt.initConfig()`.
@@ -197,15 +197,27 @@ Default value: `''`
 
 The tag message (optional).
 
+#### options.remove
+Type: `Boolean`
+Default value: `false`
+
+Whether to delete the tag (optional).
+
 ### Usage Examples
 
 ```js
 grunt.initConfig({
     gittag: {
-        task: {
+        addtag: {
             options: {
                 tag: '0.0.1',
                 message: 'Testing'
+            }
+        },
+        deletetag: {
+            options: {
+                tag: '0.0.1',
+                remove: true
             }
         }
     },

--- a/lib/command_tag.js
+++ b/lib/command_tag.js
@@ -15,6 +15,10 @@ module.exports = function (task, exec, done) {
         return;
     }
 
+    if (options.remove === true) {
+        args.push('-d');
+    }
+
     if (options.message && options.message.trim() !== '') {
         args.push('-m');
         args.push(options.message);

--- a/test/tag_test.js
+++ b/test/tag_test.js
@@ -24,4 +24,15 @@ describe('tag', function () {
             .expect(['tag', '-m', 'Test', '0.0.1'])
             .run(done);
     });
+
+    it('should remove a tag', function (done) {
+        var options = {
+            tag: '0.0.1',
+            remove: true
+        };
+
+        new Test(command, options)
+            .expect(['tag', '-d', '0.0.1'])
+            .run(done);
+    });
 });


### PR DESCRIPTION
It would be nice if I could delete tags. Currently I have a release process that reads the version number from a version.json file and automatically creates the tag locally and then pushes it:

```
git tag releases/x.y.z
git push --tags
```

These 2 commands can be achieved currently with `grunt-git`

Occasionally I make a mistake and would like to undo this :o 

```
git tag -d releases/x.y.z
git push origin :releases/x.y.z
```

The second command I can do with `gitpush` but the first I cannot do with `gittag`. I tried setting the `tag` option to `-d releases/x.y.z` but this displeases the spawn call (I don't know why).

This pull request adds a `remove` option to `gittag` to add the `-d` to the `args`  array.

I chose `remove` for the option name instead of `delete` as `delete` is a keyword and although probably fine, gets highlighted as such in editors
