### PR TITLE
Fix issue when trying to use a cwd folder outside current cwd

### DIFF
--- a/lib/command_add.js
+++ b/lib/command_add.js
@@ -3,6 +3,7 @@
 var async = require('grunt').util.async;
 var grunt = require('grunt');
 var ArgUtil = require('flopmang');
+var path = require('path');
 
 module.exports = function (task, exec, done) {
     var argUtil = new ArgUtil(task, [
@@ -24,8 +25,15 @@ module.exports = function (task, exec, done) {
     var args = ['add'].concat(argUtil.getArgFlags());
 
     task.files.forEach(function (files) {
-        for (var i = 0; i < files.src.length; i++) {
-            args.push(files.src[i]);
+        var i = 0;
+        var len = files.src.length;
+        var file;
+        for (; i < len; i++) {
+            file = files.src[i];
+            if (options.cwd) {
+                file = path.relative(options.cwd, file);
+            }
+            args.push(file);
         }
     });
 

--- a/lib/command_clean.js
+++ b/lib/command_clean.js
@@ -3,6 +3,7 @@
 var async = require('grunt').util.async;
 var grunt = require('grunt');
 var ArgUtil = require('flopmang');
+var path = require('path');
 
 module.exports = function (task, exec, done) {
     var argUtil = new ArgUtil(task, [
@@ -57,12 +58,20 @@ module.exports = function (task, exec, done) {
         },
     ]);
 
+    var options = argUtil.options;
     var args = ['clean'].concat(argUtil.getArgFlags());
 
     // Add the file paths to the arguments.
     task.files.forEach(function (files) {
-        for (var i = 0; i < files.src.length; i++) {
-            args.push(files.src[i]);
+        var i = 0;
+        var len = files.src.length;
+        var file;
+        for (; i < len; i++) {
+            file = files.src[i];
+            if (options.cwd) {
+                file = path.relative(options.cwd, file);
+            }
+            args.push(file);
         }
     });
 

--- a/lib/command_commit.js
+++ b/lib/command_commit.js
@@ -3,6 +3,7 @@
 var async = require('grunt').util.async;
 var grunt = require('grunt');
 var ArgUtil = require('flopmang');
+var path = require('path');
 
 module.exports = function (task, exec, done) {
     var argUtil = new ArgUtil(task, [
@@ -37,8 +38,15 @@ module.exports = function (task, exec, done) {
     var args = ['commit'].concat(argUtil.getArgFlags());
 
     task.files.forEach(function (files) {
-        for (var i = 0; i < files.src.length; i++) {
-            args.push(files.src[i]);
+        var i = 0;
+        var len = files.src.length;
+        var file;
+        for (; i < len; i++) {
+            file = files.src[i];
+            if (options.cwd) {
+                file = path.relative(options.cwd, file);
+            }
+            args.push(file);
         }
     });
 

--- a/lib/command_reset.js
+++ b/lib/command_reset.js
@@ -3,6 +3,7 @@
 var async = require('grunt').util.async;
 var grunt = require('grunt');
 var ArgUtil = require('flopmang');
+var path = require('path');
 
 module.exports = function (task, exec, done) {
     var argUtil = new ArgUtil(task, [
@@ -31,8 +32,15 @@ module.exports = function (task, exec, done) {
 
     if (!options.mode) {
         task.files.forEach(function (files) {
-            for (var i = 0; i < files.src.length; i++) {
-                args.push(files.src[i]);
+            var i = 0;
+            var len = files.src.length;
+            var file;
+            for (; i < len; i++) {
+                file = files.src[i];
+                if (options.cwd) {
+                    file = path.relative(options.cwd, file);
+                }
+                args.push(file);
             }
         });
     }


### PR DESCRIPTION
This pull request fix an issue when trying to use a **cwd** folder outside **grunt directory** _(eg: ../other/repo)_.

Files are not found in other repo because they are not relative to the new **cwd**.
This patch use the **path.relative** method of node to correct paths.
