### PR TITLE
Added a callback feature to all tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,28 @@ grunt.initConfig({
 })
 ```
 
+#### options.callback
+Type: `function`
+Default value: `none`
+
+If defined, describe a function to be run after the async command has returned. The first argument is the `done` function to be called.
+
+#### Example:
+```js
+grunt.initConfig({
+  gitpull: {
+    your_target: {
+      options: {
+        callback: function(done){
+          myCustomFunction();
+          done();
+        }
+      }
+    }
+  },
+})
+```
+
 ## The "gitadd" task
 
 Add file contents to the index

--- a/tasks/git.js
+++ b/tasks/git.js
@@ -10,19 +10,34 @@
 
 var commands = require('../lib/commands');
 
-module.exports = function (grunt) {
+module.exports = function(grunt) {
 
     function wrapCommand(fn) {
-        return function () {
+        return function() {
             var self = this;
 
             function exec() {
                 var args = Array.prototype.slice.call(arguments);
-                var callback = args.pop();
+                var callback;
                 var options = self.options({
                     verbose: false
                 });
                 var spawnOpts = {};
+
+                //i can define a callback in my tasks. 
+                //  if so, done function is passed as arguments
+                //  otherwise is called after the execution of the task
+                if (options.callback) {
+                    var cb = args.pop();
+                    callback = function() {
+                        var args = Array.prototype.slice.call(arguments);
+                        args = [cb].concat(args);
+                        options.callback.apply(this, args);
+                    };
+
+                } else {
+                    callback = args.pop();
+                }
 
                 //build spawn options based on task options
                 if (options.cwd) {
@@ -30,16 +45,18 @@ module.exports = function (grunt) {
                     if (grunt.file.isDir(options.cwd)) {
                         spawnOpts.cwd = options.cwd;
                     } else {
-                        throw new Error('The specified cwd does not exist: "' + options.cwd  + '"');
+                        throw new Error('The specified cwd does not exist: "' + options.cwd + '"');
                     }
                 }
-                if (options.verbose) { spawnOpts.stdio = 'inherit'; }
+                if (options.verbose) {
+                    spawnOpts.stdio = 'inherit';
+                }
 
                 grunt.util.spawn({
                     cmd: 'git',
                     args: args,
                     opts: spawnOpts
-                }, function () {
+                }, function() {
                     callback.apply(this, arguments);
                 });
             }


### PR DESCRIPTION
Added a callback feature to all tasks by modifying few lines in `/tasks/git.js`  file.

This edit came out after I needed to move files into another folder after they have been downloaded with a `gitpull`  task.

Modified code chunks lay at line 21 and lines from 27 to 41 (some lines are marked as modified just because we use different code-beautifier tool).

Please consider I can missing something as I'm not an expert grunt-plugin developer. Feel free to ask or modify given code.

Thanks

Emanuele 
