### PR TITLE
Fix crash with newlines in gitlog body

### DIFF
--- a/lib/command_log.js
+++ b/lib/command_log.js
@@ -4,18 +4,19 @@ var grunt = require('grunt');
 var ArgUtil = require('flopmang');
 
 var SEPARATOR = '--grunt-gitlog-separator--';
-var FORMAT =
-    '{%n' +
-    '  "hash": "%H",%n' + // commit hash
-    '  "author": {%n' +
-    '    "name": "%an",%n' + // author
-    '    "email": "%ae"%n' + // email
-    '  },%n' +
-    '  "date": "%aD",%n' + // date
-    '  "subject": "%s",%n' + // subject
-    '  "body": "%b"%n' + // body
-    '}%n' +
-    SEPARATOR; // separator
+var FORMAT = JSON.stringify({
+    hash: '%H',
+    author: {
+        name: '%an',
+        email: '%ae'
+    },
+    date: '%aD',
+    subject: '%s',
+    // NOTE: if the body has newlines, it ends up being malformed JSON, but
+    // there doesn't seem to be a way to remove/escape newlines with git-log,
+    // so newlines are escaped before parsing
+    body: '%b'
+}) + SEPARATOR;
 
 function parseLog(log) {
     try {
@@ -28,6 +29,10 @@ function parseLog(log) {
 
 function parseLogs(str) {
     var logs = str.split(SEPARATOR);
+    logs = logs.map(function (log) {
+        // escape all unescaped newlines before parsing
+        return log.trim().replace(/([^\\])([\n\r])/g, '$1\\n');
+    });
     return logs.slice(0, -1).map(parseLog);
 }
 

--- a/test/log_test.js
+++ b/test/log_test.js
@@ -3,7 +3,6 @@
 var command = require('../lib/commands').log;
 var Test = require('./_common');
 
-
 describe('log', function () {
     it('should log with default pretty format', function (done) {
         var options = {
@@ -77,6 +76,14 @@ describe('log', function () {
         };
         new Test(command, options)
             .expect(['log', '--pretty=format:' + command.format, '--no-merges', '1234..6789'], [null, { stdout: '' }])
+            .run(done);
+    });
+    it('should parse logs correctly when newlines exist in log body', function (done) {
+        var logs = '{ "hash": "hash", "author": { "name": "blah", "email": "blah@example.com" }, "date": "somedate", "subject": "thing", "body": "this\nhas\nnewlines\n:(" }--grunt-gitlog-separator--';
+        var options = {
+        };
+        new Test(command, options)
+            .expect(['log', '--pretty=format:' + command.format, '--no-merges'], [null, { stdout: logs }])
             .run(done);
     });
 });


### PR DESCRIPTION
This just escapes all newlines before JSON-parsing the formatted logs.
