### PR TITLE
Add option to gitadd to allow for git resolvable pathspecs

### DIFF
--- a/lib/command_add.js
+++ b/lib/command_add.js
@@ -17,6 +17,12 @@ module.exports = function (task, exec, done) {
             defaultValue: false,
             useAsFlag: true,
             useValue: false
+        },
+        {
+            option: 'pathSpec',
+            defaultValue: false,
+            useAsFlag: false,
+            useValue: true
         }
     ]);
 

--- a/test/add_test.js
+++ b/test/add_test.js
@@ -41,4 +41,17 @@ describe('add', function () {
             .expect(['add', '--all', '.'])
             .run(done);
     });
+
+    it('should add git pathspec format arg when pathspec is specified', function (done) {
+        var options = {
+            pathSpec: ['a/*', 'b/*']
+        };
+
+        var files = [
+        ];
+
+        new Test(command, options, files)
+            .expect(['add', 'a/*', 'b/*'])
+            .run(done);
+    });
 });


### PR DESCRIPTION
I need the ability to pass fileglob pathspecs (http://git-scm.com/docs/git-add - see the options / pathspec section) directly to the git add command without grunt attempting to resolve it to an actual explicit list of files via grunt.task.files.src.

This is particularly needed/useful for platforms (i.e. windows) that are constrained by a max command line limit of 65k characters. Providing the ability to specify pathspecs directly to the git add command is extremely valuable/useful to fix scenarios in which many files are attempting to be added in a single git add command or even when a few of the files attempting to be added have a long path.