### PR TITLE
Add description flag to commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ Default value: `'Commit'`
 
 The commit message.
 
+#### options.description
+Type: `String`
+Default value: `false`
+
+The commit description.
+
 #### options.allowEmpty
 Type: `Boolean`
 Default value: `false`

--- a/lib/command_commit.js
+++ b/lib/command_commit.js
@@ -14,6 +14,13 @@ module.exports = function (task, exec, done) {
             flag: '-m'
         },
         {
+            option: 'description',
+            defaultValue: false,
+            useAsFlag: true,
+            useValue: true,
+            flag: '-m'
+        },
+        {
             option: 'allowEmpty',
             defaultValue: false,
             useAsFlag: true,

--- a/test/commit_test.js
+++ b/test/commit_test.js
@@ -33,6 +33,28 @@ describe('commit', function () {
             .run(done);
     });
 
+    it('should use the specified commit message', function (done) {
+        var options = {
+            message: 'Testing!',
+            description: 'Moar testing!'
+        };
+
+        var files = [
+            'test.txt'
+        ];
+
+        new Test(command, options, files)
+            .expect([
+                'commit',
+                '-m',
+                'Testing!',
+                '-m',
+                'Moar testing!',
+                'test.txt'
+            ])
+            .run(done);
+    });
+
     it('should add --allow-empty arg when allowEmpty is true', function (done) {
         var options = {
             allowEmpty: true


### PR DESCRIPTION
This allows you to pass in a description as well as a message. Git syntax taken from [SO](http://bit.ly/1j6zX7s).