### PR TITLE
Grunt updated to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-git",
   "description": "Git commands for grunt.",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "homepage": "https://github.com/rubenv/grunt-git",
   "author": {
     "name": "Ruben Vermeersch",
@@ -38,7 +38,7 @@
     "grunt-mocha-cli": "~1.0.1"
   },
   "peerDependencies": {
-    "grunt": ">=0.4.0"
+    "grunt": ">=1.0.1"
   },
   "keywords": [
     "gruntplugin"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt-mocha-cli": "~1.0.1"
   },
   "peerDependencies": {
-    "grunt": ">=1.0.1"
+    "grunt": "~1.0.1"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
Grunt took a leap forward in its version, this therefore no longer works with a lot of npm modules.