### PR TITLE
Add git rev-parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,6 +803,63 @@ Default value: `false`
 
 Adds the `--tags` flag. Fetch all tags from the remote into local.
 
+## The "gitrevParse" task
+
+Pick out and massage parameters.
+
+### Overview
+
+In your project's Gruntfile, add a section named `gitrevParse` to the data object passed into `grunt.initConfig()`.
+
+```js
+grunt.initConfig({
+  gitrevParse: {
+    your_target: {
+      options: {
+        short: 7,
+        treeIsh: 'master',
+        prop: 'gitrevParse.your_target.result',
+        callback: function(result) {
+          grunt.gitrevParse.your_target.result = result;
+        }
+      }
+    }
+  }
+})
+```
+
+### Options
+
+#### options.short
+Type: `Integer`
+Default value: none.
+
+Adds the `--short=` option, set to the specified number of characters.
+
+#### options.treeIsh
+Type: `String`
+Default value: `'head'`
+
+The tree or commit object to examine.
+
+#### options.abbrevRef
+Type: `Boolean`
+Default value: `false`
+
+Adds the `--abbrev-ref` flag. Try and output the abbreviated reference for the tree-ish object instead of the SHA-1 checksum.
+
+#### options.prop
+Type: `String`
+Default value: `'gitrevParse.<target name>.result'`.
+
+The grunt property in which to store the results.
+
+#### options.callback
+Type: `Function`
+Default value: none.
+
+A callback function that is called with the rev-parse results provided as the sole parameter.
+
 ## The "gitmerge" task
 
 Merges another branch into the current branch.

--- a/lib/command_revParse.js
+++ b/lib/command_revParse.js
@@ -1,0 +1,65 @@
+'use strict';
+
+var async = require('grunt').util.async;
+var grunt = require('grunt');
+var ArgUtil = require('flopmang');
+
+module.exports = function (task, exec, done) {
+    var options = task.options({
+        prop: 'gitrevParse.' + task.target + '.result'
+    });
+
+    var argUtil = new ArgUtil(task, [
+        {
+            option: 'short',
+            useAsFlag: true,
+            useValue: false,
+            customFlagFn: function (arg) {
+                if (arg.value) {
+                    return ['--short=' + arg.value];
+                }
+                return null;
+            }
+        },
+        {
+            option: 'abbrevRef',
+            defaultValue: false,
+            useAsFlag: true,
+            useValue: false,
+            customFlagFn: function (arg) {
+                if (arg.value) {
+                    return ['--abbrev-ref'];
+                }
+                return null;
+            }
+        },
+        {
+            option: 'treeIsh',
+            defaultValue: 'head',
+            useAsFlag: false,
+            useValue: true
+        }
+    ]);
+
+    function next(error, result, code) {
+        result = result.toString();
+
+        if (options.prop) {
+            grunt.config.set(options.prop, result);
+        }
+
+        if (typeof options.callback === 'function') {
+            options.callback(result);
+        }
+
+        done();
+    }
+
+    var args = ['rev-parse'].concat(argUtil.getArgFlags());
+
+    args.push(next);
+
+    exec.apply(this, args);
+};
+
+module.exports.description = 'Pick out and massage parameters';

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -12,6 +12,7 @@ module.exports = {
     push: require('./command_push'),
     rebase: require('./command_rebase'),
     reset: require('./command_reset'),
+    revParse: require('./command_revParse'),
     rm: require('./command_rm'),
     stash: require('./command_stash'),
     tag: require('./command_tag'),

--- a/test/revParse_test.js
+++ b/test/revParse_test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var command = require('../lib/commands').revParse;
+var Test = require('./_common');
+
+describe('rev-parse', function () {
+    it('should print the full SHA-1 checksum of head by default', function (done) {
+        var options = {};
+
+        new Test(command, options)
+            .expect(['rev-parse', 'head'])
+            .run(done);
+    });
+
+    it('should print a partial SHA-1 checksum of the given number of characters', function (done) {
+        var options = {
+            short: 7
+        };
+
+        new Test(command, options)
+            .expect(['rev-parse', '--short=7', 'head'])
+            .run(done);
+    });
+
+    it('should print the SHA-1 checksum of a specified tree or commit', function (done) {
+        var options = {
+            treeIsh: 'some-object'
+        };
+
+        new Test(command, options)
+            .expect(['rev-parse', 'some-object'])
+            .run(done);
+    });
+
+    it('should print the abbreviated reference for a specified tree or commit', function (done) {
+        var options = {
+            abbrevRef: true
+        };
+
+        new Test(command, options)
+            .expect(['rev-parse', '--abbrev-ref', 'head'])
+            .run(done);
+    });
+});


### PR DESCRIPTION
With a little inspiration from the `gitlog` task (returning the parameters via a property or a callback).