### PR TITLE
gitmerge: Add support for nolog option (--no-log)

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,6 +899,12 @@ Default value: `false`
 
 Will add the `--no-ff` flag to the merge.
 
+#### options.noff
+Type: `Boolean`
+Default value: `false`
+
+Will add the `--no-log` flag to the merge.
+
 #### options.squash
 Type: `Boolean`
 Default value: `false`

--- a/lib/command_merge.js
+++ b/lib/command_merge.js
@@ -32,6 +32,13 @@ module.exports = function (task, exec, done) {
             flag: '--no-ff'
         },
         {
+            option: 'nolog',
+            defaultValue: false,
+            useAsFlag: true,
+            useValue: false,
+            flag: '--no-log'
+        },
+        {
             option: 'edit',
             defaultValue: false,
             useAsFlag: true,


### PR DESCRIPTION
Use case: Preventing a summary of the commits being merged from being added to the merge commit message, even though the user has this in their `~/.gitconfig`:

```
[merge]
log=true
```

This broke for me in a release flow where a `[ci skip]` in the message of one of the commits being merged prevented the resulting merge commit from being CIed :). Adding this switch would make us immune to that particular problem.