### PR TITLE
support of multiple gitclean "exclude" values

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,10 +631,25 @@ Default value: `false`
 Be quiet, only report errors, but not the files that are successfully removed (optional).
 
 #### options.exclude
-Type: `String`
+Type: `String`/`Array`
 Default value: `false`
 
 In addition to those found in .gitignore (per directory) and $GIT_DIR/info/exclude, also consider the given patterns to be in the set of the ignore rules in effect (optional).
+
+In case it's needed to provide multiple patterns one should use an array:
+
+```js
+grunt.initConfig({
+  gitclean: {
+    your_target: {
+      options: {
+        exclude: ['.env', 'config.php']
+      },
+      ...
+    }
+  },
+})
+```
 
 #### options.onlyignorefiles
 Type: `Boolean`

--- a/lib/command_clean.js
+++ b/lib/command_clean.js
@@ -30,9 +30,27 @@ module.exports = function (task, exec, done) {
         {
             option: 'exclude',
             defaultValue: false,
-            useAsFlag: true,
-            useValue: true,
-            flag: '-e'
+            useValue: false,
+            flag: '-e',
+            // "exclude" option could be used multiple times
+            // in this case the values are provided in an array
+            customFlagFn: function (arg) {
+                var value  = arg.value;
+                var flag   = arg.flag;
+                var result = null;
+
+                if (value) {
+                    value  = Array.isArray(value) ? value : [value];
+                    result = [];
+
+                    value.forEach(function (path) {
+                        result.push(flag);
+                        result.push(path);
+                    });
+                }
+
+                return result;
+            }
         },
         {
             option: 'onlyignoredfiles',

--- a/test/clean_test.js
+++ b/test/clean_test.js
@@ -52,6 +52,16 @@ describe('clean', function () {
             .run(done);
     });
 
+    it('should support multiple exclude patterns', function (done) {
+        var options = {
+            exclude: ['*.log', 'local.env']
+        };
+
+        new Test(command, options)
+            .expect(['clean', '-f', '-e', '*.log', '-e', 'local.env'])
+            .run(done);
+    });
+
     it('should have use a non-standard matching pattern', function (done) {
         var options = {
             nonstandard: true


### PR DESCRIPTION
added support of multiple patterns in git-clean "exclude" option:
`git clean -e pattern1 -e pattern2`

